### PR TITLE
Stop using deprecated classes

### DIFF
--- a/Extension/SafeTransExtension.php
+++ b/Extension/SafeTransExtension.php
@@ -3,6 +3,7 @@ namespace Arthens\SafeTranslation\Extension;
 
 use Arthens\SafeTranslation\TokenParser\SafeTransChoiceTokenParser;
 use Arthens\SafeTranslation\TokenParser\SafeTransTokenParser;
+use Twig_SimpleFilter as SimpleFilter;
 
 class SafeTransExtension extends \Twig_Extension
 {
@@ -14,7 +15,7 @@ class SafeTransExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            self::DO_NOT_ESCAPE => new \Twig_Filter_Method($this, 'unescaped'),
+             new SimpleFilter(self::DO_NOT_ESCAPE, array($this, 'unescaped')),
         );
     }
 

--- a/Node/SafeTransNode.php
+++ b/Node/SafeTransNode.php
@@ -7,10 +7,10 @@ use Twig_Node_Expression_Filter as Filter;
 
 class SafeTransNode extends TransNode
 {
-    /**
+    /*
      * Re-define compileString to automatically escape variables, unless they have been marked as |unescaped
      */
-    protected function compileString(\Twig_NodeInterface $body, \Twig_Node_Expression_Array $vars, $ignoreStrictCheck = false)
+    protected function compileString(\Twig_Node $body, \Twig_Node_Expression_Array $vars, $ignoreStrictCheck = false)
     {
         // Extract the message to be translated, or return if it doesn't need translations
         if ($body instanceof \Twig_Node_Expression_Constant) {

--- a/Tests/Extension/SafeTransExtensionTest.php
+++ b/Tests/Extension/SafeTransExtensionTest.php
@@ -15,7 +15,7 @@ class SafeTransExtensionTest extends \PHPUnit_Framework_TestCase
 
         // filters
         $filters = $extension->getFilters();
-        $this->assertTrue(array_key_exists("unescaped", $filters));
+        $this->assertEquals("unescaped", $filters[0]->getName());
 
         // tags
         $tokens = $extension->getTokenParsers();


### PR DESCRIPTION
Using `arthen/safe-translations` with `twig/twig` >= 1.23 generate warning about deprecated classes being used.

This pull request fixed the issue by:
- Replacing deprecated Twig_Filter_Method with Twig_SimpleFilter
- Updating SafeTransNode function signature to match parent