### PR TITLE
Update Twig and PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 
 php:
-  - 5.5
-  - 5.4
-  - 5.3
+  - 7.1
+  - 7.0
 
 before_script:
   - composer install --dev --prefer-dist

--- a/Node/SafeTransNode.php
+++ b/Node/SafeTransNode.php
@@ -23,14 +23,14 @@ class SafeTransNode extends TransNode
 
         // Escape variable passed using 'with'
         // {% safetrans with {...} %}{% endsafetrans %}
-        $vars = $this->escapeWithVariables($vars, $body->getLine());
+        $vars = $this->escapeWithVariables($vars, $body->getTemplateLine());
 
         // Escape variables that needs to be read from $context
         // {% safetrans %}...{% endsafetrans %}
-        $vars = $this->escapeContextVariables($msg, $vars, $body->getLine());
+        $vars = $this->escapeContextVariables($msg, $vars, $body->getTemplateLine());
 
         return array(
-            new \Twig_Node_Expression_Constant(str_replace('%%', '%', trim($msg)), $body->getLine()),
+            new \Twig_Node_Expression_Constant(str_replace('%%', '%', trim($msg)), $body->getTemplateLine()),
             $vars
         );
     }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 [![Build Status](https://travis-ci.org/arthens/safe-translations.svg?branch=master)](https://travis-ci.org/arthens/safe-translations)
 
+## Compatibility
+
+Version 1.0 is PHP 7.* and Twig 2.* only.
+
+Version 0.4 is the last version supporting PHP 5.* and Twig 1.*
+
 ## The problem
 
 [Twig](http://twig.sensiolabs.org/) is a great rendering library, and it's also awesome for protecting against
@@ -87,4 +93,4 @@ This might change with future versions. Pull requests are welcome.
 
 #### 5. Is this production ready?
 
-Try it out and decide yourself. [99designs](http://99designs.com) has been using it for longer than 1 year without any problem.
+[99designs](https://99designs.com) has been using it in production since 2013.

--- a/Tests/Node/SafeTransNodeTest.php
+++ b/Tests/Node/SafeTransNodeTest.php
@@ -11,11 +11,11 @@ class SafeTransNodeTest extends \PHPUnit_Framework_TestCase
         $vars = new \Twig_Node_Expression_Name('foo', 0);
         $node = new SafeTransNode($body, null, null, $vars);
 
-        $env = new \Twig_Environment(null, array('strict_variables' => true));
+        $env = new \Twig_Environment(new \Twig_Loader_Array(), array('strict_variables' => true));
         $compiler = new \Twig_Compiler($env);
 
         $this->assertEquals(sprintf(
-                'echo $this->env->getExtension(\'translator\')->getTranslator()->trans("Hello %%name%%", array_merge(array("%%name%%" => twig_escape_filter($this->env, %s)), %s), "messages");',
+                'echo $this->env->getExtension(\'Symfony\Bridge\Twig\Extension\TranslationExtension\')->getTranslator()->trans("Hello %%name%%", array_merge(array("%%name%%" => twig_escape_filter($this->env, %s)), %s), "messages");',
                 $this->getVariableGetter('name'),
                 $this->getVariableGetter('foo')
             ),
@@ -26,7 +26,7 @@ class SafeTransNodeTest extends \PHPUnit_Framework_TestCase
     protected function getVariableGetter($name)
     {
         if (version_compare(phpversion(), '5.4.0RC1', '>=')) {
-            return sprintf('(isset($context["%s"]) ? $context["%s"] : $this->getContext($context, "%s"))', $name, $name, $name);
+            return sprintf('(isset($context["%s"]) || array_key_exists("%s", $context) ? $context["%s"] : (function () { throw new Twig_Error_Runtime(\'Variable "%s" does not exist.\', 0, $this->getSourceContext()); })())', $name, $name, $name, $name);
         }
 
         return sprintf('$this->getContext($context, "%s")', $name);

--- a/Tests/TokenParser/SafeTransChoiceTokenParserTest.php
+++ b/Tests/TokenParser/SafeTransChoiceTokenParserTest.php
@@ -23,8 +23,7 @@ class SafeTransChoiceTokenParserTest extends \PHPUnit_Framework_TestCase
             '{0} Hello %name%|{1} Goodbye %name%' => '{0} Ciao %name%|{1} Arrivederci %name%',
         ), 'it', 'dom');
 
-        $loader = new \Twig_Loader_String();
-        $this->twig = new \Twig_Environment($loader);
+        $this->twig = new \Twig_Environment(new \Twig_Loader_Array());
         $this->twig->addExtension(new TranslationExtension($this->translator));
         $this->twig->addExtension(new SafeTransExtension());
     }
@@ -34,15 +33,14 @@ class SafeTransChoiceTokenParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testTransChoice()
     {
-        $template = "{% transchoice count %}{0} Hello %name%|{1} Goodbye %name%{% endtranschoice %}";
-
-        $html = $this->twig->render($template, array(
+        $template = $this->twig->createTemplate("{% transchoice count %}{0} Hello %name%|{1} Goodbye %name%{% endtranschoice %}");
+        $html = $template->render(array(
             'count' => 0,
             'name' => "<script>alert();</script>",
         ));
         $this->assertEquals("Hello <script>alert();</script>", $html);
 
-        $html = $this->twig->render($template, array(
+        $html = $template->render(array(
             'count' => 1,
             'name' => "<script>alert();</script>",
         ));
@@ -51,15 +49,15 @@ class SafeTransChoiceTokenParserTest extends \PHPUnit_Framework_TestCase
 
     public function testSafeTransChoice()
     {
-        $template = "{% safetranschoice count %}{0} Hello %name%|{1} Goodbye %name%{% endsafetranschoice %}";
+        $template = $this->twig->createTemplate("{% safetranschoice count %}{0} Hello %name%|{1} Goodbye %name%{% endsafetranschoice %}");
 
-        $html = $this->twig->render($template, array(
+        $html = $template->render(array(
             'count' => 0,
             'name' => "<script>alert();</script>",
         ));
         $this->assertEquals("Hello &lt;script&gt;alert();&lt;/script&gt;", $html);
 
-        $html = $this->twig->render($template, array(
+        $html = $template->render(array(
             'count' => 1,
             'name' => "<script>alert();</script>",
         ));
@@ -68,15 +66,15 @@ class SafeTransChoiceTokenParserTest extends \PHPUnit_Framework_TestCase
 
     public function testSafeTransChoiceAndWith()
     {
-        $template = "{% safetranschoice count with {'%name%': name} %}{0} Hello %name%|{1} Goodbye %name%{% endsafetranschoice %}";
+        $template = $this->twig->createTemplate("{% safetranschoice count with {'%name%': name} %}{0} Hello %name%|{1} Goodbye %name%{% endsafetranschoice %}");
 
-        $html = $this->twig->render($template, array(
+        $html = $template->render(array(
             'count' => 0,
             'name' => "<script>alert();</script>",
         ));
         $this->assertEquals("Hello &lt;script&gt;alert();&lt;/script&gt;", $html);
 
-        $html = $this->twig->render($template, array(
+        $html = $template->render(array(
             'count' => 1,
             'name' => "<script>alert();</script>",
         ));
@@ -85,19 +83,19 @@ class SafeTransChoiceTokenParserTest extends \PHPUnit_Framework_TestCase
 
     public function testSafeTransChoiceAndWithNoEscape()
     {
-        $template = "{% safetranschoice count with {
+        $template = $this->twig->createTemplate("{% safetranschoice count with {
             '%name%': name,
             '%what%': what|unescaped,
-            } %}{0} Hello %name%, you are %what%|{1} Goodbye %name%, you are %what%{% endsafetranschoice %}";
+            } %}{0} Hello %name%, you are %what%|{1} Goodbye %name%, you are %what%{% endsafetranschoice %}");
 
-        $html = $this->twig->render($template, array(
+        $html = $template->render(array(
             'count' => 0,
             'name' => "<script>alert();</script>",
             'what' => "<b>awesome</b>",
         ));
         $this->assertEquals("Hello &lt;script&gt;alert();&lt;/script&gt;, you are <b>awesome</b>", $html);
 
-        $html = $this->twig->render($template, array(
+        $html = $template->render(array(
             'count' => 1,
             'name' => "<script>alert();</script>",
             'what' => "<b>awesome</b>",
@@ -107,15 +105,15 @@ class SafeTransChoiceTokenParserTest extends \PHPUnit_Framework_TestCase
 
     public function testSafeTransChoiceAndDomain()
     {
-        $template = "{% safetranschoice count from 'dom' into 'it' %}{0} Hello %name%|{1} Goodbye %name%{% endsafetranschoice %}";
+        $template = $this->twig->createTemplate("{% safetranschoice count from 'dom' into 'it' %}{0} Hello %name%|{1} Goodbye %name%{% endsafetranschoice %}");
 
-        $html = $this->twig->render($template, array(
+        $html = $template->render(array(
             'count' => 0,
             'name' => "<script>alert();</script>",
         ));
         $this->assertEquals("Ciao &lt;script&gt;alert();&lt;/script&gt;", $html);
 
-        $html = $this->twig->render($template, array(
+        $html = $template->render(array(
             'count' => 1,
             'name' => "<script>alert();</script>",
         ));

--- a/Tests/TokenParser/SafeTransTokenParserTest.php
+++ b/Tests/TokenParser/SafeTransTokenParserTest.php
@@ -23,8 +23,7 @@ class SafeTransTokenParserTest extends \PHPUnit_Framework_TestCase
             'Hello %name%' => 'Ciao %name%',
         ), 'it', 'dom');
 
-        $loader = new \Twig_Loader_String();
-        $this->twig = new \Twig_Environment($loader);
+        $this->twig = new \Twig_Environment(new \Twig_Loader_Array());
         $this->twig->addExtension(new TranslationExtension($this->translator));
         $this->twig->addExtension(new SafeTransExtension());
     }
@@ -34,7 +33,9 @@ class SafeTransTokenParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testTrans()
     {
-        $html = $this->twig->render("{% trans %}Hello %name%{% endtrans %}", array(
+        $template = $this->twig->createTemplate("{% trans %}Hello %name%{% endtrans %}");
+
+        $html = $template->render(array(
             'name' => "<script>alert();</script>",
         ));
         $this->assertEquals("Hello <script>alert();</script>", $html);
@@ -42,7 +43,9 @@ class SafeTransTokenParserTest extends \PHPUnit_Framework_TestCase
 
     public function testSafeTrans()
     {
-        $html = $this->twig->render("{% safetrans %}Hello %name%{% endsafetrans %}", array(
+        $template = $this->twig->createTemplate("{% safetrans %}Hello %name%{% endsafetrans %}");
+
+        $html = $template->render(array(
             'name' => "<script>alert();</script>",
         ));
         $this->assertEquals("Hello &lt;script&gt;alert();&lt;/script&gt;", $html);
@@ -50,8 +53,9 @@ class SafeTransTokenParserTest extends \PHPUnit_Framework_TestCase
 
     public function testSafeTransAndWith()
     {
-        $template = "{% safetrans with {'%name%': name} %}Hello %name%{% endsafetrans %}";
-        $html = $this->twig->render($template, array(
+        $template = $this->twig->createTemplate("{% safetrans with {'%name%': name} %}Hello %name%{% endsafetrans %}");
+
+        $html = $template->render(array(
             'name' => "<script>alert();</script>",
         ));
         $this->assertEquals("Hello &lt;script&gt;alert();&lt;/script&gt;", $html);
@@ -59,12 +63,12 @@ class SafeTransTokenParserTest extends \PHPUnit_Framework_TestCase
 
     public function testSafeTransWithNoEscape()
     {
-        $template = "{% safetrans with {
+        $template = $this->twig->createTemplate("{% safetrans with {
             '%name%': name,
             '%what%': what|unescaped,
-            } %}Hello %name%, you are %what%{% endsafetrans %}";
+            } %}Hello %name%, you are %what%{% endsafetrans %}");
 
-        $html = $this->twig->render($template, array(
+        $html = $template->render(array(
             'name' => "<script>alert();</script>",
             'what' => "<b>awesome</b>",
         ));
@@ -73,7 +77,9 @@ class SafeTransTokenParserTest extends \PHPUnit_Framework_TestCase
 
     public function testSafeTransAndDomain()
     {
-        $html = $this->twig->render("{% safetrans from 'dom' into 'it' %}Hello %name%{% endsafetrans %}", array(
+        $template = $this->twig->createTemplate("{% safetrans from 'dom' into 'it' %}Hello %name%{% endsafetrans %}");
+
+        $html = $template->render(array(
             'name' => "<script>alert();</script>",
         ));
         $this->assertEquals("Ciao &lt;script&gt;alert();&lt;/script&gt;", $html);

--- a/TokenParser/SafeTransChoiceTokenParser.php
+++ b/TokenParser/SafeTransChoiceTokenParser.php
@@ -12,7 +12,7 @@ class SafeTransChoiceTokenParser extends TransChoiceTokenParser
      *
      * @param  \Twig_Token         $token A Twig_Token instance
      * @throws \Twig_Error_Syntax
-     * @return \Twig_NodeInterface A Twig_NodeInterface instance
+     * @return SafeTransNode A Twig_NodeInterface instance
      */
     public function parse(\Twig_Token $token)
     {
@@ -27,7 +27,7 @@ class SafeTransChoiceTokenParser extends TransChoiceTokenParser
             $node->hasNode('count') ? $node->getNode('count') : null,
             $node->hasNode('vars') ? $node->getNode('vars') : null,
             $node->hasNode('locale') ? $node->getNode('locale') : null,
-            $node->getLine(),
+            $node->getTemplateLine(),
             $this->getTag()
         );
     }

--- a/TokenParser/SafeTransTokenParser.php
+++ b/TokenParser/SafeTransTokenParser.php
@@ -28,7 +28,7 @@ class SafeTransTokenParser extends TransTokenParser
             null,
             $node->hasNode('vars') ? $node->getNode('vars') : null,
             $node->hasNode('locale') ? $node->getNode('locale') : null,
-            $node->getLine(),
+            $node->getTemplateLine(),
             $this->getTag()
         );
     }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Automatically escape variables when using Symfony Translations",
     "license": "MIT",
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.6.0",
         "twig/twig": "~2",
         "symfony/twig-bridge": "~2.3",
         "symfony/translation": "~2.3"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.2",
-        "twig/twig": "~1.13",
+        "twig/twig": "~2",
         "symfony/twig-bridge": "~2.3",
         "symfony/translation": "~2.3"
     },


### PR DESCRIPTION
## Changes
- Update token parser for twig 2.* compiler. Drop twig 1.* support.
- Add support for PHP 7.0 and 7.1. Drop support for PHP 5.3, 5.4, 5.5 and 5.6.