### PR TITLE
ComposerJSON: Include Symfony 4 in the version range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "require": {
         "php": ">=5.6.0",
         "twig/twig": "~2",
-        "symfony/twig-bridge": "~3",
-        "symfony/translation": "~3"
+        "symfony/twig-bridge": "~3|~4",
+        "symfony/translation": "~3|~4"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7"


### PR DESCRIPTION
Opens up the range inclusion for the Symfony dependencies to include v4